### PR TITLE
06_timers time of previous call module

### DIFF
--- a/06_timers/03_time_for_prev/Makefile
+++ b/06_timers/03_time_for_prev/Makefile
@@ -1,0 +1,18 @@
+PWD := $(shell pwd)
+
+ifneq ($(KERNELRELEASE),)
+	obj-m := time_oprev.o
+else
+	KDIR ?= /lib/modules/`uname -r`/build
+
+default:
+	$(MAKE) -C $(KDIR) M=$(PWD)
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+
+check:
+	$(KDIR)/scripts/checkpatch.pl -f time_oprev.c
+send:
+	sudo cp time_oprev.ko test.sh /srv/nfs/busybox/tmp
+
+endif

--- a/06_timers/03_time_for_prev/test.log
+++ b/06_timers/03_time_for_prev/test.log
@@ -1,0 +1,22 @@
+/tmp # ./test.sh
+Testing up_converter moudule
+[ 6884.916746] time_oprev: init success
+
+Read device data:
+It's a first call, there are no previos calls
+
+Sleep 1.2 sec...
+Read device data:
+Time of the last call - 6884.930976904 sec
+
+Sleep 2.2 sec...
+Read device data:
+Time of the last call - 6886.151450279 sec
+
+Sleep 1.1 sec...
+Read device data:
+Time of the last call - 6888.370284612 sec
+
+Read device data:
+Time of the last call - 6889.488454946 sec
+[ 6889.734629] time_oprev: module release!

--- a/06_timers/03_time_for_prev/test.sh
+++ b/06_timers/03_time_for_prev/test.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+module="time_oprev.ko"
+path="/sys/class/time_oprev"
+device=get_ptime
+delay=1.2
+delay2=2.2
+delay3=1.1
+
+echo "Testing up_converter moudule"
+insmod ${module}
+
+echo ""
+echo "Read device data:"
+cat $path/$device
+
+echo ""
+echo "Sleep $delay sec..."
+sleep ${delay}s
+echo "Read device data:"
+cat $path/$device
+
+echo ""
+echo "Sleep $delay2 sec..."
+sleep ${delay2}s
+echo "Read device data:"
+cat $path/$device
+
+echo ""
+echo "Sleep $delay3 sec..."
+sleep ${delay3}s
+echo "Read device data:"
+cat $path/$device
+
+echo ""
+echo "Read device data:"
+cat $path/$device
+
+sleep 0.2s
+rmmod ${module}

--- a/06_timers/03_time_for_prev/time_oprev.c
+++ b/06_timers/03_time_for_prev/time_oprev.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/bug.h>
+#include <linux/device.h>
+#include <linux/delay.h>
+#include <linux/uaccess.h>
+#include <linux/ktime.h>
+#include <media/rc-core.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Oleksiy Lyubochko <oleksiy.m.lyubochko@globallogic.com>");
+MODULE_DESCRIPTION("A simple example Linux module.");
+MODULE_VERSION("0.01");
+
+#define BUF_SIZE 256
+#define MODULE_NAME "time_oprev"
+#define CLASS_NAME MODULE_NAME
+#define STAMP_STRING "Time of the last call - %ld.%09ld sec\n"
+#define STAMP_STRING_FIRST "It's a first call, there are no previos calls\n"
+#define DELAY_IN_MS 0
+#define DELAY_IN_SEC 5
+
+static struct class *attr_class;
+
+static ssize_t get_ptime_show(struct class *class, struct class_attribute *attr,
+		char *st_buf)
+{
+	size_t len;
+	struct timespec stamp_spec;
+	static ktime_t timestamp = {0};
+
+	stamp_spec = ktime_to_timespec(timestamp);
+	timestamp = ktime_get();
+
+	/* Only for the first call */
+	if (unlikely(!stamp_spec.tv_sec || !stamp_spec.tv_nsec)) {
+		len = strlen(STAMP_STRING_FIRST);
+		memcpy(st_buf, STAMP_STRING_FIRST, len);
+		return len;
+	}
+
+	return snprintf(st_buf, BUF_SIZE, STAMP_STRING, stamp_spec.tv_sec,
+			stamp_spec.tv_nsec);
+
+}
+
+CLASS_ATTR_RO(get_ptime);
+
+static int __init time_oprev_init(void)
+{
+	int ret;
+
+	attr_class = class_create(THIS_MODULE, CLASS_NAME);
+	if (attr_class == NULL) {
+		pr_err(MODULE_NAME ": error creating sysfs class\n");
+		return -ENOMEM;
+	}
+
+	ret = class_create_file(attr_class, &class_attr_get_ptime);
+	if (ret) {
+		pr_err(MODULE_NAME ": error creating sysfs class attribute\n");
+		class_destroy(attr_class);
+		return ret;
+	}
+
+	pr_info(MODULE_NAME ": init success\n");
+
+	return 0;
+}
+
+static void __exit time_oprev_exit(void)
+{
+	class_remove_file(attr_class, &class_attr_get_ptime);
+	class_destroy(attr_class);
+
+	pr_info(MODULE_NAME ": module release!\n");
+}
+
+module_init(time_oprev_init);
+module_exit(time_oprev_exit);

--- a/06_timers/README.md
+++ b/06_timers/README.md
@@ -1,0 +1,11 @@
+# Homework
+
+1. Implement program which return absolute time in user space.
+
+2. Implement kernel module with API in sysfs, 
+ which returns relation time in maximum possible
+ resolution passed since previous read of it.
+
+3. Implement kernel module with API in sysfs
+ which returns absolute time of previous reading
+ with maximum resolution like ‘400.123567’ seconds.


### PR DESCRIPTION
This module returns time of previous device reading in "/sys/class/time_oprev" directory.