### PR TITLE
03 module

### DIFF
--- a/03_module/Makefile
+++ b/03_module/Makefile
@@ -1,0 +1,9 @@
+obj-m += simple_module.o
+
+BUILD_KERNEL ?= ~/repos/busybox/_install/lib/modules/4.19.177/build
+KDIR ?= ~/repos/linux-stable
+
+all:
+	make -C $(BUILD_KERNEL) M=$(PWD) modules
+clean:
+	make -C $(BUILD_KERNEL) M=$(PWD) clean

--- a/03_module/README.md
+++ b/03_module/README.md
@@ -1,0 +1,9 @@
+## simple module home work:  create the simplest kernel loadable module
+
+1. Create a simple kernel module (C source and makefile).
+2. Add some debug prints.
+3. Check your source with the checkpatch.pl
+4. Add module parameter and implement different module_init return codes 
+   dependent on this parameter (OK/Error).
+5. Get kernel logs for both cases.
+Please add your sources and makefile into folder '03_module'

--- a/03_module/log.txt
+++ b/03_module/log.txt
@@ -1,0 +1,20 @@
+$ ./scripts/checkpatch.pl -f ~/Kernel_Pro/03_module/simple_module.c
+
+>> total: 0 errors, 0 warnings, 35 lines checked
+>> /home/nazar/Kernel_Pro/03_module/simple_module.c has no obvious style problems and is ready for submission.
+
+/ # insmod simple_module.ko param=-1
+[ 3244.004451] Simple module init error - -1
+
+/ # insmod simple_module.ko
+insmod: can't insert 'simple_module.ko': File exists
+
+/ # rmmod simple_module
+[ 4162.020005] Simple module exit!
+
+/ # insmod simple_module.ko param=0
+[ 4127.784477] Simple module init success!
+
+/ # insmod simple_module.ko
+[ 4176.183817] Simple module init success!
+

--- a/03_module/simple_module.c
+++ b/03_module/simple_module.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("Dual MIT/GPL");
+MODULE_AUTHOR("Nazar Sopiha  <nazar.sopiha@globallogic.com>");
+MODULE_DESCRIPTION("The simplest Linux module.");
+MODULE_VERSION("1.0");
+
+static int param = 0;
+
+
+module_param(param, int, 0644);
+MODULE_PARM_DESC(param, "Test Parameter, integer type ");
+
+
+static int __init simple_module_init(void)
+{
+	if (param) {
+		pr_err("Simple module init error - %d\n", param);
+		return -1;
+	}
+
+	pr_info("Simple module init success!\n");
+	return 0;
+}
+
+static void __exit simple_module_exit(void)
+{
+	pr_info("Simple module exit!\n");
+}
+
+module_init(simple_module_init);
+module_exit(simple_module_exit);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # gl-kernel-training-2021
 Linux kernel general course by GlobalLogic, 2021
+
+This repository is aimed for sharing our exercises and your solutions in scope of the course.
+
+Homeworks:
+- hwdetect - detect attached hardware using user level script file
+
+
+Please refer to wiki for details.


### PR DESCRIPTION
Add the simplest kernel Module
Notes to the Makefile: You can specify KDIR before make and  BUILD_Kernel is hardcoded. Not sure it's correct.
To build it for BBB you should specify env variable ARCH=arm.
You can see logs of adding the module in log.txt

Somewhy this merge request sees the differences for scissors task (2nd one). Maybe I did something wrong with git.
Or maybe it's because scissors is not merged into main/nazar.sopiha yet. Don't think it's that important, just mentioning