### PR TITLE
09 dt rtc

### DIFF
--- a/09_dt_rtc/0001-09_DT_RTC-Add-dts-overlay-source-to-modify-eeprom-co.patch
+++ b/09_dt_rtc/0001-09_DT_RTC-Add-dts-overlay-source-to-modify-eeprom-co.patch
@@ -1,0 +1,42 @@
+From 8cc3a77f231b0defab60031e8170a6506e52a218 Mon Sep 17 00:00:00 2001
+From: Maryna Malakhova <maryna.malakhova@globallogic.com>
+Date: Wed, 7 Apr 2021 14:39:20 +0300
+Subject: [PATCH] 09_DT_RTC: Add dts overlay source to modify eeprom compatible
+
+Add dts overlay source to modify eeprom compatible
+
+Signed-off-by: Maryna Malakhova <maryna.malakhova@globallogic.com>
+---
+ .../arm/boot/dts/BBB_black_eeprom3_ds3231.dts | 20 +++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+ create mode 100644 arch/arm/boot/dts/BBB_black_eeprom3_ds3231.dts
+
+diff --git a/arch/arm/boot/dts/BBB_black_eeprom3_ds3231.dts b/arch/arm/boot/dts/BBB_black_eeprom3_ds3231.dts
+new file mode 100644
+index 000000000000..4092bb6995ed
+--- /dev/null
++++ b/arch/arm/boot/dts/BBB_black_eeprom3_ds3231.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++fragment@0 {
++	target = <&GLCamp>;
++		__overlay__ {
++		i2c2 {
++		#address-cells = <1>;
++                #size-cells = <0>;
++		compatible = "ti,beaglebone", "ti,beaglebone-black";
++		cape_eeprom3: cape_eeprom3@57 {
++			compatible = "maxim,ds3231";
++			reg = <0x57>;
++				};
++			};
++		};
++	};
++};
++
+--
+2.25.1
+

--- a/09_dt_rtc/0001-09_DT_RTC-Add-rtc0-to-original-dts.patch
+++ b/09_dt_rtc/0001-09_DT_RTC-Add-rtc0-to-original-dts.patch
@@ -1,0 +1,31 @@
+From 55c85fa4e87ca717033392d80fb665bb11f6f595 Mon Sep 17 00:00:00 2001
+From: Maryna Malakhova <maryna.malakhova@globallogic.com>
+Date: Wed, 7 Apr 2021 13:29:55 +0300
+Subject: [PATCH] 09_DT_RTC: Add rtc0 to original dts
+
+Add rtc0 to original am335x-boneblack.dts
+
+Signed-off-by: Maryna Malakhova <maryna.malakhova@globallogic.com>
+---
+ arch/arm/boot/dts/am335x-boneblack.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
+index d154d3133c16..1a8adbf6ac91 100644
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
+@@ -26,3 +26,11 @@
+		opp-supported-hw = <0x06 0x0100>;
+	};
+ };
++
++&i2c2 {
++	rtc0: ds3231@0 {
++		compatible = "maxim,ds3231";
++		reg = <0x68>;
++	};
++};
++
+--
+2.25.1
+

--- a/09_dt_rtc/0001-09_DT_RTC-Add-source-of-rtc0-adding-overlay.patch
+++ b/09_dt_rtc/0001-09_DT_RTC-Add-source-of-rtc0-adding-overlay.patch
@@ -1,0 +1,46 @@
+From 03dc7fc357cc9ffa853a1f64eb34fb550be1f4a5 Mon Sep 17 00:00:00 2001
+From: Maryna Malakhova <maryna.malakhova@globallogic.com>
+Date: Wed, 7 Apr 2021 13:36:00 +0300
+Subject: [PATCH] 09_DT_RTC: Add source of rtc0 adding overlay
+
+Add source of rtc0 adding overlay to the device tree
+Build command: dtc -@ -O dtb -o BBB_black_rtc0.dtbo BBB_black_rtc0.dts
+BBB_black_rtc0.dtbo compiles without any errors
+I have some questions about it`s bootloading by netboot
+I would be appreciate for a help
+
+Signed-off-by: Maryna Malakhova <maryna.malakhova@globallogic.com>
+---
+ arch/arm/boot/dts/BBB_black_rtc0.dts | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+ create mode 100644 arch/arm/boot/dts/BBB_black_rtc0.dts
+
+diff --git a/arch/arm/boot/dts/BBB_black_rtc0.dts b/arch/arm/boot/dts/BBB_black_rtc0.dts
+new file mode 100644
+index 000000000000..1a66a89a3b45
+--- /dev/null
++++ b/arch/arm/boot/dts/BBB_black_rtc0.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++fragment@0 {
++	target = <&GLCamp>;
++		__overlay__ {
++		i2c2 {
++		#address-cells = <1>;
++                #size-cells = <0>;
++		compatible = "ti,beaglebone", "ti,beaglebone-black";
++		ds3231: rtc@0 {
++			compatible = "maxim, ds3231";
++			reg = <0x68>;
++				};
++			};
++		};
++	};
++};
++
+--
+2.25.1
+


### PR DESCRIPTION
09_dt_rtc homework. Add variant to modify original am335x-boneblack.dts. It has been built by make and tested on BBB.
Add two overlays (rtc0 and eeprom). Overlays have been built to the *.dtbo files by dtc compiller successfully.
But I have some questions about overlays' deploying